### PR TITLE
feat: :sparkles: Adds endpoint to retrieve expense details

### DIFF
--- a/src/main/java/mr/limpios/smart_divide_backend/aplication/assemblers/ExpenseDetailAssembler.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/aplication/assemblers/ExpenseDetailAssembler.java
@@ -21,7 +21,7 @@ public class ExpenseDetailAssembler {
     List<ExpenseBalanceDTO> balances = buildBalancesDetails(expense.balances());
 
     return new ExpenseDetailDTO(expense.id(), expense.type(), expense.description(),
-        expense.amount(), expense.createdAt(), payers, balances);
+        expense.amount(), expense.createdAt(), expense.evidenceUrl(), payers, balances);
   }
 
   private static List<ExpensePayerDetail> buildPayersDetails(

--- a/src/main/java/mr/limpios/smart_divide_backend/aplication/assemblers/ExpenseDetailAssembler.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/aplication/assemblers/ExpenseDetailAssembler.java
@@ -1,14 +1,15 @@
 package mr.limpios.smart_divide_backend.aplication.assemblers;
 
-import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails.DebtorBalanceDTO;
 import mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails.ExpenseBalanceDTO;
 import mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails.ExpenseDetailDTO;
 import mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails.ExpenseParticipantDTO;
-import mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails.ExpensePayerDetail;
+import mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails.ExpensePayerDetailDTO;
 import mr.limpios.smart_divide_backend.domain.models.Expense;
 import mr.limpios.smart_divide_backend.domain.models.ExpenseBalance;
 import mr.limpios.smart_divide_backend.domain.models.ExpenseParticipant;
@@ -17,32 +18,39 @@ import mr.limpios.smart_divide_backend.domain.models.User;
 public class ExpenseDetailAssembler {
 
   public static ExpenseDetailDTO buildExpenseDetailDTO(Expense expense) {
-    List<ExpensePayerDetail> payers = buildPayersDetails(expense.participants());
-    List<ExpenseBalanceDTO> balances = buildBalancesDetails(expense.balances());
+    List<ExpenseParticipant> participants =
+        expense.participants() == null ? List.of() : expense.participants();
+    Map<String, ExpenseParticipant> participantsByUser = participants.stream()
+        .collect(Collectors.toMap(p -> p.payer().id(), Function.identity(), (a, b) -> a));
+
+    List<ExpenseBalanceDTO> balances =
+        groupBalancesByCreditor(expense.balances(), participantsByUser);
 
     return new ExpenseDetailDTO(expense.id(), expense.type(), expense.description(),
-        expense.amount(), expense.createdAt(), expense.evidenceUrl(), payers, balances);
+        expense.amount(), expense.createdAt(), expense.evidenceUrl(), balances);
   }
 
-  private static List<ExpensePayerDetail> buildPayersDetails(
-      List<ExpenseParticipant> participants) {
-    return participants.stream().filter(p -> p.amountPaid().compareTo(BigDecimal.ZERO) > 0)
-        .map(p -> new ExpensePayerDetail(toExpenseParticipantDTO(p.payer()), p.amountPaid(),
-            p.amountPaid().subtract(p.mustPaid())))
+  private static List<ExpenseBalanceDTO> groupBalancesByCreditor(List<ExpenseBalance> balances,
+      Map<String, ExpenseParticipant> participantsByUser) {
+
+    return balances.stream().collect(Collectors.groupingBy(ExpenseBalance::creditor)).entrySet()
+        .stream().map(e -> buildBalanceForCreditor(e.getKey(), e.getValue(), participantsByUser))
         .toList();
   }
 
-  private static List<ExpenseBalanceDTO> buildBalancesDetails(List<ExpenseBalance> balances) {
-    return balances.stream().collect(Collectors.groupingBy(ExpenseBalance::creditor)).entrySet()
-        .stream().map(entry -> {
-          User creditor = entry.getKey();
-          List<DebtorBalanceDTO> debtors = entry.getValue().stream()
-              .map(balance -> new DebtorBalanceDTO(toExpenseParticipantDTO(balance.debtor()),
-                  balance.amountToPaid()))
-              .toList();
+  private static ExpenseBalanceDTO buildBalanceForCreditor(User creditor,
+      List<ExpenseBalance> balancesForCreditor,
+      Map<String, ExpenseParticipant> participantsByUser) {
+    ExpenseParticipant participant = participantsByUser.get(creditor.id());
 
-          return new ExpenseBalanceDTO(toExpenseParticipantDTO(creditor), debtors);
-        }).toList();
+    ExpensePayerDetailDTO payer = new ExpensePayerDetailDTO(toExpenseParticipantDTO(creditor),
+        participant.amountPaid(), participant.amountPaid().subtract(participant.mustPaid()));
+
+    List<DebtorBalanceDTO> debtors = balancesForCreditor.stream()
+        .map(b -> new DebtorBalanceDTO(toExpenseParticipantDTO(b.debtor()), b.amountToPaid()))
+        .toList();
+
+    return new ExpenseBalanceDTO(payer, debtors);
   }
 
   private static ExpenseParticipantDTO toExpenseParticipantDTO(User user) {

--- a/src/main/java/mr/limpios/smart_divide_backend/aplication/assemblers/ExpenseDetailAssembler.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/aplication/assemblers/ExpenseDetailAssembler.java
@@ -1,0 +1,51 @@
+package mr.limpios.smart_divide_backend.aplication.assemblers;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails.DebtorBalanceDTO;
+import mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails.ExpenseBalanceDTO;
+import mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails.ExpenseDetailDTO;
+import mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails.ExpenseParticipantDTO;
+import mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails.ExpensePayerDetail;
+import mr.limpios.smart_divide_backend.domain.models.Expense;
+import mr.limpios.smart_divide_backend.domain.models.ExpenseBalance;
+import mr.limpios.smart_divide_backend.domain.models.ExpenseParticipant;
+import mr.limpios.smart_divide_backend.domain.models.User;
+
+public class ExpenseDetailAssembler {
+
+  public static ExpenseDetailDTO buildExpenseDetailDTO(Expense expense) {
+    List<ExpensePayerDetail> payers = buildPayersDetails(expense.participants());
+    List<ExpenseBalanceDTO> balances = buildBalancesDetails(expense.balances());
+
+    return new ExpenseDetailDTO(expense.id(), expense.type(), expense.description(),
+        expense.amount(), expense.createdAt(), payers, balances);
+  }
+
+  private static List<ExpensePayerDetail> buildPayersDetails(
+      List<ExpenseParticipant> participants) {
+    return participants.stream().filter(p -> p.amountPaid().compareTo(BigDecimal.ZERO) > 0)
+        .map(p -> new ExpensePayerDetail(toExpenseParticipantDTO(p.payer()), p.amountPaid()))
+        .toList();
+  }
+
+  private static List<ExpenseBalanceDTO> buildBalancesDetails(List<ExpenseBalance> balances) {
+    return balances.stream().collect(Collectors.groupingBy(ExpenseBalance::creditor)).entrySet()
+        .stream().map(entry -> {
+          User creditor = entry.getKey();
+          List<DebtorBalanceDTO> debtors = entry.getValue().stream()
+              .map(balance -> new DebtorBalanceDTO(toExpenseParticipantDTO(balance.debtor()),
+                  balance.amountToPaid()))
+              .toList();
+
+          return new ExpenseBalanceDTO(toExpenseParticipantDTO(creditor), debtors);
+        }).toList();
+  }
+
+  private static ExpenseParticipantDTO toExpenseParticipantDTO(User user) {
+    return new ExpenseParticipantDTO(user.id(), user.name(), user.lastName(), user.photoUrl());
+  }
+
+}

--- a/src/main/java/mr/limpios/smart_divide_backend/aplication/assemblers/ExpenseDetailAssembler.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/aplication/assemblers/ExpenseDetailAssembler.java
@@ -27,7 +27,8 @@ public class ExpenseDetailAssembler {
   private static List<ExpensePayerDetail> buildPayersDetails(
       List<ExpenseParticipant> participants) {
     return participants.stream().filter(p -> p.amountPaid().compareTo(BigDecimal.ZERO) > 0)
-        .map(p -> new ExpensePayerDetail(toExpenseParticipantDTO(p.payer()), p.amountPaid()))
+        .map(p -> new ExpensePayerDetail(toExpenseParticipantDTO(p.payer()), p.amountPaid(),
+            p.amountPaid().subtract(p.mustPaid())))
         .toList();
   }
 

--- a/src/main/java/mr/limpios/smart_divide_backend/aplication/assemblers/ExpenseModelAssembler.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/aplication/assemblers/ExpenseModelAssembler.java
@@ -5,8 +5,8 @@ import java.util.*;
 import java.util.function.Predicate;
 
 import mr.limpios.smart_divide_backend.aplication.utils.CollectionUtils;
+import mr.limpios.smart_divide_backend.domain.dto.CreateExpenseParticipantDTO;
 import mr.limpios.smart_divide_backend.domain.dto.ExpenseInputDTO;
-import mr.limpios.smart_divide_backend.domain.dto.ExpenseParticipantDTO;
 import mr.limpios.smart_divide_backend.domain.models.*;
 
 public class ExpenseModelAssembler {
@@ -14,10 +14,11 @@ public class ExpenseModelAssembler {
       ExpenseInputDTO addExpenseDTO, Map<String, User> groupMembersMap) {
 
     Map<String, BigDecimal> payersMap = CollectionUtils.toMap(addExpenseDTO.payers(),
-        ExpenseParticipantDTO::userId, payer -> BigDecimal.valueOf(payer.amount()));
+        CreateExpenseParticipantDTO::userId, payer -> BigDecimal.valueOf(payer.amount()));
 
-    Map<String, BigDecimal> participantsMap = CollectionUtils.toMap(addExpenseDTO.participants(),
-        ExpenseParticipantDTO::userId, participant -> BigDecimal.valueOf(participant.amount()));
+    Map<String, BigDecimal> participantsMap =
+        CollectionUtils.toMap(addExpenseDTO.participants(), CreateExpenseParticipantDTO::userId,
+            participant -> BigDecimal.valueOf(participant.amount()));
 
     Set<String> allMemberIds = new HashSet<>();
     allMemberIds.addAll(payersMap.keySet());
@@ -62,10 +63,11 @@ public class ExpenseModelAssembler {
       ExpenseInputDTO addExpenseDTO, Map<String, User> groupMembersMap) {
 
     Map<String, BigDecimal> payersMap = CollectionUtils.toMap(addExpenseDTO.payers(),
-        ExpenseParticipantDTO::userId, payer -> BigDecimal.valueOf(payer.amount()));
+        CreateExpenseParticipantDTO::userId, payer -> BigDecimal.valueOf(payer.amount()));
 
-    Map<String, BigDecimal> participantsMap = CollectionUtils.toMap(addExpenseDTO.participants(),
-        ExpenseParticipantDTO::userId, participant -> BigDecimal.valueOf(participant.amount()));
+    Map<String, BigDecimal> participantsMap =
+        CollectionUtils.toMap(addExpenseDTO.participants(), CreateExpenseParticipantDTO::userId,
+            participant -> BigDecimal.valueOf(participant.amount()));
 
     Map<String, BigDecimal> balances = balanceCalculation(payersMap, participantsMap);
 

--- a/src/main/java/mr/limpios/smart_divide_backend/aplication/repositories/ExpenseRepository.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/aplication/repositories/ExpenseRepository.java
@@ -1,7 +1,6 @@
 package mr.limpios.smart_divide_backend.aplication.repositories;
 
 import java.util.List;
-import java.util.Optional;
 
 import mr.limpios.smart_divide_backend.domain.models.Expense;
 

--- a/src/main/java/mr/limpios/smart_divide_backend/aplication/services/ExpenseService.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/aplication/services/ExpenseService.java
@@ -2,6 +2,7 @@ package mr.limpios.smart_divide_backend.aplication.services;
 
 import static mr.limpios.smart_divide_backend.domain.constants.ExceptionsConstants.EXPENSE_NOT_FOUND;
 import static mr.limpios.smart_divide_backend.domain.constants.ExceptionsConstants.GROUP_NOT_FOUND;
+import static mr.limpios.smart_divide_backend.domain.constants.ExceptionsConstants.USER_NOT_MEMBER_OF_GROUP;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -84,12 +85,24 @@ public class ExpenseService {
       throw new ResourceNotFoundException(EXPENSE_NOT_FOUND);
     }
 
+    validateUserAccessToExpense(expense, userId, groupId);
+    return ExpenseDetailAssembler.buildExpenseDetailDTO(expense);
+  }
+
+  private void validateUserAccessToExpense(Expense expense, String userId, String groupId) {
+    if (!expense.group().id().equals(groupId)) {
+      throw new ResourceNotFoundException(EXPENSE_NOT_FOUND);
+    }
+
     Group group = groupRepository.getGroupById(groupId);
     if (Objects.isNull(group)) {
       throw new ResourceNotFoundException(GROUP_NOT_FOUND);
     }
 
-    return ExpenseDetailAssembler.buildExpenseDetailDTO(expense);
+    boolean isMember = group.members().stream().anyMatch(member -> member.id().equals(userId));
+    if (!isMember) {
+      throw new ResourceNotFoundException(USER_NOT_MEMBER_OF_GROUP);
+    }
   }
 
   public List<UserBalanceDTO> getUserBalancesByGroup(String groupId, String userId) {

--- a/src/main/java/mr/limpios/smart_divide_backend/aplication/services/ExpenseService.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/aplication/services/ExpenseService.java
@@ -12,20 +12,22 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import mr.limpios.smart_divide_backend.aplication.repositories.ExpenseBalanceRepository;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
+import mr.limpios.smart_divide_backend.aplication.assemblers.ExpenseDetailAssembler;
 import mr.limpios.smart_divide_backend.aplication.assemblers.ExpenseModelAssembler;
+import mr.limpios.smart_divide_backend.aplication.repositories.ExpenseBalanceRepository;
 import mr.limpios.smart_divide_backend.aplication.repositories.ExpenseGroupBalanceRepository;
 import mr.limpios.smart_divide_backend.aplication.repositories.ExpenseRepository;
 import mr.limpios.smart_divide_backend.aplication.repositories.GroupRepository;
 import mr.limpios.smart_divide_backend.aplication.utils.CollectionUtils;
-import mr.limpios.smart_divide_backend.domain.dto.ExpenseDetailDTO;
+import mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails.ExpenseDetailDTO;
 import mr.limpios.smart_divide_backend.domain.dto.ExpenseInputDTO;
 import mr.limpios.smart_divide_backend.domain.dto.ExpensePayerDTO;
+import mr.limpios.smart_divide_backend.domain.dto.ExpenseSummaryDTO;
 import mr.limpios.smart_divide_backend.domain.dto.UserBalanceDTO;
 import mr.limpios.smart_divide_backend.domain.events.ExpenseCreatedEvent;
 import mr.limpios.smart_divide_backend.domain.exceptions.ResourceNotFoundException;
@@ -76,12 +78,26 @@ public class ExpenseService {
     eventPublisher.publishEvent(new ExpenseCreatedEvent(savedExpense));
   }
 
+  public ExpenseDetailDTO getExpenseDetails(String expenseId, String userId, String groupId) {
+    Expense expense = expenseRepository.findById(expenseId);
+    if (Objects.isNull(expense)) {
+      throw new ResourceNotFoundException(EXPENSE_NOT_FOUND);
+    }
+
+    Group group = groupRepository.getGroupById(groupId);
+    if (Objects.isNull(group)) {
+      throw new ResourceNotFoundException(GROUP_NOT_FOUND);
+    }
+
+    return ExpenseDetailAssembler.buildExpenseDetailDTO(expense);
+  }
+
   public List<UserBalanceDTO> getUserBalancesByGroup(String groupId, String userId) {
     List<ExpenseGroupBalance> asCreditor =
-            groupBalanceRepository.findByGroupIdAndCreditorId(groupId, userId);
+        groupBalanceRepository.findByGroupIdAndCreditorId(groupId, userId);
 
     List<ExpenseGroupBalance> asDebtor =
-            groupBalanceRepository.findByGroupIdAndDebtorId(groupId, userId);
+        groupBalanceRepository.findByGroupIdAndDebtorId(groupId, userId);
 
     Stream<UserBalanceDTO> creditorStream =
         asCreditor.stream().map(balance -> new UserBalanceDTO(balance.debtor().id(),
@@ -99,14 +115,14 @@ public class ExpenseService {
         .values().stream().filter(Optional::isPresent).map(Optional::get).toList();
   }
 
-  public List<ExpenseDetailDTO> getExpensesByGroup(String groupId,
+  public List<ExpenseSummaryDTO> getExpensesByGroup(String groupId,
       List<UserBalanceDTO> userBalances, String userId) {
     List<Expense> expenses = expenseRepository.findByGroupId(groupId);
 
     Map<String, BigDecimal> balanceMap = userBalances.stream()
         .collect(Collectors.toMap(UserBalanceDTO::userId, UserBalanceDTO::balance));
 
-    List<ExpenseDetailDTO> result = new ArrayList<>();
+    List<ExpenseSummaryDTO> result = new ArrayList<>();
 
     for (Expense expense : expenses) {
       result.add(buildExpenseDetailDTO(expense, balanceMap, userId));
@@ -115,7 +131,7 @@ public class ExpenseService {
     return result;
   }
 
-  private ExpenseDetailDTO buildExpenseDetailDTO(Expense expense,
+  private ExpenseSummaryDTO buildExpenseDetailDTO(Expense expense,
       Map<String, BigDecimal> balanceMap, String userId) {
     List<ExpensePayerDTO> payers =
         expense.participants().stream().filter(p -> p.amountPaid().compareTo(BigDecimal.ZERO) > 0)
@@ -128,31 +144,28 @@ public class ExpenseService {
     BigDecimal userBalance =
         payer != null ? payer.amountPaid().subtract(payer.mustPaid()) : BigDecimal.ZERO;
 
-    return new ExpenseDetailDTO(expense.id(), expense.type(), expense.description(),
+    return new ExpenseSummaryDTO(expense.id(), expense.type(), expense.description(),
         expense.amount(), expense.createdAt(), payers, userBalance);
   }
 
   @Transactional
   public void deleteExpense(String expenseId) {
 
-      Expense expenseToDelete = expenseRepository.findById(expenseId);
-      if (Objects.isNull(expenseToDelete)) {
-          throw new ResourceNotFoundException(EXPENSE_NOT_FOUND);
-      }
-      Group group = expenseToDelete.group();
-      List<ExpenseBalance> transactionsToReverse = expenseBalanceRepository.findAllByExpenseId(expenseId);
+    Expense expenseToDelete = expenseRepository.findById(expenseId);
+    if (Objects.isNull(expenseToDelete)) {
+      throw new ResourceNotFoundException(EXPENSE_NOT_FOUND);
+    }
+    Group group = expenseToDelete.group();
+    List<ExpenseBalance> transactionsToReverse =
+        expenseBalanceRepository.findAllByExpenseId(expenseId);
 
-      for (ExpenseBalance expenseBalance : transactionsToReverse) {
+    for (ExpenseBalance expenseBalance : transactionsToReverse) {
 
-          expenseGroupBalanceService.applyReverseBalance(
-                  expenseBalance.creditor(),
-                  expenseBalance.debtor(),
-                  expenseBalance.amountToPaid(),
-                  group
-          );
+      expenseGroupBalanceService.applyReverseBalance(expenseBalance.creditor(),
+          expenseBalance.debtor(), expenseBalance.amountToPaid(), group);
 
-          expenseRepository.deleteById(expenseId);
-      }
+      expenseRepository.deleteById(expenseId);
+    }
   }
 
 }

--- a/src/main/java/mr/limpios/smart_divide_backend/aplication/services/GroupService.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/aplication/services/GroupService.java
@@ -143,7 +143,7 @@ public class GroupService {
     }
 
     List<UserBalanceDTO> userBalances = expenseService.getUserBalancesByGroup(groupId, userId);
-    List<ExpenseDetailDTO> expenses =
+    List<ExpenseSummaryDTO> expenses =
         expenseService.getExpensesByGroup(groupId, userBalances, userId);
     List<PaymentDetailDTO> payments = paymentService.getPaymentsByGroup(groupId);
 

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/dto/CreateExpenseParticipantDTO.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/dto/CreateExpenseParticipantDTO.java
@@ -1,0 +1,4 @@
+package mr.limpios.smart_divide_backend.domain.dto;
+
+public record CreateExpenseParticipantDTO(String userId, double amount) {
+}

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/DebtorBalanceDTO.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/DebtorBalanceDTO.java
@@ -1,0 +1,7 @@
+package mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails;
+
+import java.math.BigDecimal;
+
+public record DebtorBalanceDTO(ExpenseParticipantDTO debtor, BigDecimal amount) {
+
+}

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpenseBalanceDTO.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpenseBalanceDTO.java
@@ -3,7 +3,7 @@ package mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails;
 import java.util.List;
 
 public record ExpenseBalanceDTO(
-        ExpenseParticipantDTO payer,
+        ExpensePayerDetailDTO payer,
         List<DebtorBalanceDTO> debtors) {
 
 }

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpenseBalanceDTO.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpenseBalanceDTO.java
@@ -1,0 +1,9 @@
+package mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails;
+
+import java.util.List;
+
+public record ExpenseBalanceDTO(
+        ExpenseParticipantDTO payer,
+        List<DebtorBalanceDTO> debtors) {
+
+}

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpenseDetailDTO.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpenseDetailDTO.java
@@ -5,12 +5,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record ExpenseDetailDTO(
-                String id,
-                String type,
-                String description,
-                BigDecimal amount,
-                LocalDateTime createdAt,
-                String evidenceUrl,
-                List<ExpensePayerDetail> payers,
-                List<ExpenseBalanceDTO> balances) {
+        String id,
+        String type,
+        String description,
+        BigDecimal amount,
+        LocalDateTime createdAt,
+        String evidenceUrl,
+        List<ExpenseBalanceDTO> balances) {
 }

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpenseDetailDTO.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpenseDetailDTO.java
@@ -10,6 +10,7 @@ public record ExpenseDetailDTO(
                 String description,
                 BigDecimal amount,
                 LocalDateTime createdAt,
+                String evidenceUrl,
                 List<ExpensePayerDetail> payers,
                 List<ExpenseBalanceDTO> balances) {
 }

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpenseDetailDTO.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpenseDetailDTO.java
@@ -1,0 +1,15 @@
+package mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ExpenseDetailDTO(
+                String id,
+                String type,
+                String description,
+                BigDecimal amount,
+                LocalDateTime createdAt,
+                List<ExpensePayerDetail> payers,
+                List<ExpenseBalanceDTO> balances) {
+}

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpenseParticipantDTO.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpenseParticipantDTO.java
@@ -1,0 +1,4 @@
+package mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails;
+
+public record ExpenseParticipantDTO(String userId, String name, String lastName, String photoUrl) {
+}

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpensePayerDetail.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpensePayerDetail.java
@@ -1,0 +1,6 @@
+package mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails;
+
+import java.math.BigDecimal;
+
+public record ExpensePayerDetail(ExpenseParticipantDTO participant, BigDecimal amountPaid) {
+}

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpensePayerDetail.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpensePayerDetail.java
@@ -1,6 +1,0 @@
-package mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails;
-
-import java.math.BigDecimal;
-
-public record ExpensePayerDetail(ExpenseParticipantDTO participant, BigDecimal amountPaid, BigDecimal amountBorrowed) {
-}

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpensePayerDetail.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpensePayerDetail.java
@@ -2,5 +2,5 @@ package mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails;
 
 import java.math.BigDecimal;
 
-public record ExpensePayerDetail(ExpenseParticipantDTO participant, BigDecimal amountPaid) {
+public record ExpensePayerDetail(ExpenseParticipantDTO participant, BigDecimal amountPaid, BigDecimal amountBorrowed) {
 }

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpensePayerDetailDTO.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseDetails/ExpensePayerDetailDTO.java
@@ -1,0 +1,6 @@
+package mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails;
+
+import java.math.BigDecimal;
+
+public record ExpensePayerDetailDTO(ExpenseParticipantDTO participant, BigDecimal amountPaid, BigDecimal amountBorrowed) {
+}

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseInputDTO.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseInputDTO.java
@@ -9,6 +9,6 @@ public record ExpenseInputDTO(
         double amount,
         String evidenceUrl,
         DivisionType divisionType,
-        List<ExpenseParticipantDTO> payers,
-        List<ExpenseParticipantDTO> participants
+        List<CreateExpenseParticipantDTO> payers,
+        List<CreateExpenseParticipantDTO> participants
 ) {}

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseParticipantDTO.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseParticipantDTO.java
@@ -1,4 +1,0 @@
-package mr.limpios.smart_divide_backend.domain.dto;
-
-public record ExpenseParticipantDTO(String userId, double amount) {
-}

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseSummaryDTO.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/dto/ExpenseSummaryDTO.java
@@ -4,7 +4,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record ExpenseDetailDTO(
+public record ExpenseSummaryDTO(
         String id,
         String type,
         String description,

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/dto/GroupTransactionHistoryDTO.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/dto/GroupTransactionHistoryDTO.java
@@ -10,6 +10,6 @@ public record GroupTransactionHistoryDTO(
         String type,
         List<UserBalanceDTO> userBalance,
         List<PaymentDetailDTO> payments,
-        List<ExpenseDetailDTO> expenses
+        List<ExpenseSummaryDTO> expenses
 ) {
 }

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/validators/ExpenseValidator.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/validators/ExpenseValidator.java
@@ -6,8 +6,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import mr.limpios.smart_divide_backend.domain.dto.CreateExpenseParticipantDTO;
 import mr.limpios.smart_divide_backend.domain.dto.ExpenseInputDTO;
-import mr.limpios.smart_divide_backend.domain.dto.ExpenseParticipantDTO;
 import mr.limpios.smart_divide_backend.domain.exceptions.ResourceNotFoundException;
 import mr.limpios.smart_divide_backend.domain.models.User;
 
@@ -21,9 +21,9 @@ public class ExpenseValidator {
     HashSet<String> memberIds = new HashSet<>(membersMap.keySet());
 
     HashSet<String> dtoParticipantsIds = dto.participants().stream()
-        .map(ExpenseParticipantDTO::userId).collect(Collectors.toCollection(HashSet::new));
+        .map(CreateExpenseParticipantDTO::userId).collect(Collectors.toCollection(HashSet::new));
 
-    HashSet<String> dtoPayersIds = dto.payers().stream().map(ExpenseParticipantDTO::userId)
+    HashSet<String> dtoPayersIds = dto.payers().stream().map(CreateExpenseParticipantDTO::userId)
         .collect(Collectors.toCollection(HashSet::new));
 
     if (!memberIds.containsAll(dtoParticipantsIds)) {

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/validators/strategies/AbstractExpenseValidationStrategy.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/validators/strategies/AbstractExpenseValidationStrategy.java
@@ -4,8 +4,8 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import mr.limpios.smart_divide_backend.domain.constants.ExceptionsConstants;
+import mr.limpios.smart_divide_backend.domain.dto.CreateExpenseParticipantDTO;
 import mr.limpios.smart_divide_backend.domain.dto.ExpenseInputDTO;
-import mr.limpios.smart_divide_backend.domain.dto.ExpenseParticipantDTO;
 import mr.limpios.smart_divide_backend.domain.exceptions.InvalidDataException;
 
 public abstract class AbstractExpenseValidationStrategy
@@ -19,7 +19,7 @@ public abstract class AbstractExpenseValidationStrategy
     }
   }
 
-  protected BigDecimal getSumOfAmount(List<ExpenseParticipantDTO> memberList) {
+  protected BigDecimal getSumOfAmount(List<CreateExpenseParticipantDTO> memberList) {
     return memberList.stream().map(p -> BigDecimal.valueOf(p.amount())).reduce(BigDecimal.ZERO,
         BigDecimal::add);
   }

--- a/src/main/java/mr/limpios/smart_divide_backend/domain/validators/strategies/EqualDivisionValidationStrategy.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/domain/validators/strategies/EqualDivisionValidationStrategy.java
@@ -7,8 +7,8 @@ import java.math.RoundingMode;
 
 import org.springframework.stereotype.Component;
 
+import mr.limpios.smart_divide_backend.domain.dto.CreateExpenseParticipantDTO;
 import mr.limpios.smart_divide_backend.domain.dto.ExpenseInputDTO;
-import mr.limpios.smart_divide_backend.domain.dto.ExpenseParticipantDTO;
 import mr.limpios.smart_divide_backend.domain.exceptions.InvalidDataException;
 
 @Component
@@ -31,7 +31,7 @@ public class EqualDivisionValidationStrategy extends AbstractExpenseValidationSt
     BigDecimal expectedShare = totalAmount.divide(count, 2, RoundingMode.HALF_UP);
     BigDecimal tolerance = new BigDecimal("0.01");
 
-    for (ExpenseParticipantDTO participant : dto.participants()) {
+    for (CreateExpenseParticipantDTO participant : dto.participants()) {
       BigDecimal actualShare = BigDecimal.valueOf(participant.amount());
       BigDecimal difference = actualShare.subtract(expectedShare).abs();
 

--- a/src/main/java/mr/limpios/smart_divide_backend/infraestructure/controllers/ExpenseController.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/infraestructure/controllers/ExpenseController.java
@@ -13,7 +13,9 @@ import mr.limpios.smart_divide_backend.domain.dto.WrapperResponse;
 
 @RestController
 @RequestMapping("user/{userId}/groups/{groupId}/expense")
-@CrossOrigin(maxAge = 3600, methods = {RequestMethod.OPTIONS, RequestMethod.POST}, origins = {"*"})
+@CrossOrigin(maxAge = 3600,
+    methods = {RequestMethod.OPTIONS, RequestMethod.POST, RequestMethod.GET, RequestMethod.DELETE},
+    origins = {"*"})
 @Tag(name = "Expense", description = "Endpoints for managing expenses")
 public class ExpenseController {
   private final ExpenseService expenseService;

--- a/src/main/java/mr/limpios/smart_divide_backend/infraestructure/controllers/ExpenseController.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/infraestructure/controllers/ExpenseController.java
@@ -26,7 +26,7 @@ public class ExpenseController {
 
   @Operation(summary = "Create a new expense")
   @PostMapping
-  public ResponseEntity<WrapperResponse<Object>> AddExpense(@PathVariable String userId,
+  public ResponseEntity<WrapperResponse<Object>> addExpense(@PathVariable String userId,
       @PathVariable String groupId, @RequestBody ExpenseInputDTO expenseInputDTO) {
     expenseService.addExpense(expenseInputDTO, userId, groupId);
     return new ResponseEntity<>(new WrapperResponse<>(true, "Expense created successfully", null),
@@ -37,7 +37,7 @@ public class ExpenseController {
   @Operation(summary = "Get expense details")
   @GetMapping("{expenseId}")
   public ResponseEntity<WrapperResponse<ExpenseDetailDTO>> getExpenseDetail(
-      @PathVariable String expenseId, @PathVariable String userId, @PathVariable String groupId) {
+      @PathVariable String userId, @PathVariable String groupId, @PathVariable String expenseId) {
     ExpenseDetailDTO expenseDetailDTO =
         expenseService.getExpenseDetails(expenseId, userId, groupId);
 

--- a/src/main/java/mr/limpios/smart_divide_backend/infraestructure/controllers/ExpenseController.java
+++ b/src/main/java/mr/limpios/smart_divide_backend/infraestructure/controllers/ExpenseController.java
@@ -7,39 +7,47 @@ import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import mr.limpios.smart_divide_backend.aplication.services.ExpenseService;
+import mr.limpios.smart_divide_backend.domain.dto.ExpenseDetails.ExpenseDetailDTO;
 import mr.limpios.smart_divide_backend.domain.dto.ExpenseInputDTO;
 import mr.limpios.smart_divide_backend.domain.dto.WrapperResponse;
 
 @RestController
 @RequestMapping("user/{userId}/groups/{groupId}/expense")
-@CrossOrigin(maxAge = 3600, methods = { RequestMethod.OPTIONS, RequestMethod.POST }, origins = {
-        "*" })
+@CrossOrigin(maxAge = 3600, methods = {RequestMethod.OPTIONS, RequestMethod.POST}, origins = {"*"})
 @Tag(name = "Expense", description = "Endpoints for managing expenses")
 public class ExpenseController {
-    private final ExpenseService expenseService;
+  private final ExpenseService expenseService;
 
-    public ExpenseController(ExpenseService expenseService) {
-        this.expenseService = expenseService;
-    }
+  public ExpenseController(ExpenseService expenseService) {
+    this.expenseService = expenseService;
+  }
 
-    @Operation(summary = "Create a new expense")
-    @PostMapping
-    public ResponseEntity<WrapperResponse<Object>> AddExpense(
-            @PathVariable String userId,
-            @PathVariable String groupId,
-            @RequestBody ExpenseInputDTO expenseInputDTO) {
-        expenseService.addExpense(expenseInputDTO, userId, groupId);
-        return new ResponseEntity<>(
-                new WrapperResponse<>(true, "Expense created successfully", null),
-                HttpStatus.CREATED);
+  @Operation(summary = "Create a new expense")
+  @PostMapping
+  public ResponseEntity<WrapperResponse<Object>> AddExpense(@PathVariable String userId,
+      @PathVariable String groupId, @RequestBody ExpenseInputDTO expenseInputDTO) {
+    expenseService.addExpense(expenseInputDTO, userId, groupId);
+    return new ResponseEntity<>(new WrapperResponse<>(true, "Expense created successfully", null),
+        HttpStatus.CREATED);
 
-    }
+  }
 
-    @Operation(summary = "Deletes an existing expense")
-    @DeleteMapping("{expenseId}")
-    public ResponseEntity<Void> deleteExpense(
-            @PathVariable String expenseId) {
-        expenseService.deleteExpense(expenseId);
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
-    }
+  @Operation(summary = "Get expense details")
+  @GetMapping("{expenseId}")
+  public ResponseEntity<WrapperResponse<ExpenseDetailDTO>> getExpenseDetail(
+      @PathVariable String expenseId, @PathVariable String userId, @PathVariable String groupId) {
+    ExpenseDetailDTO expenseDetailDTO =
+        expenseService.getExpenseDetails(expenseId, userId, groupId);
+
+    return new ResponseEntity<>(
+        new WrapperResponse<>(true, "Expense details retrieved successfully", expenseDetailDTO),
+        HttpStatus.OK);
+  }
+
+  @Operation(summary = "Deletes an existing expense")
+  @DeleteMapping("{expenseId}")
+  public ResponseEntity<Void> deleteExpense(@PathVariable String expenseId) {
+    expenseService.deleteExpense(expenseId);
+    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
 }

--- a/src/test/java/mr/limpios/smart_divide_backend/aplication/services/ExpenseServiceTest.java
+++ b/src/test/java/mr/limpios/smart_divide_backend/aplication/services/ExpenseServiceTest.java
@@ -33,8 +33,8 @@ import mr.limpios.smart_divide_backend.aplication.assemblers.ExpenseModelAssembl
 import mr.limpios.smart_divide_backend.aplication.repositories.ExpenseGroupBalanceRepository;
 import mr.limpios.smart_divide_backend.aplication.repositories.ExpenseRepository;
 import mr.limpios.smart_divide_backend.aplication.repositories.GroupRepository;
-import mr.limpios.smart_divide_backend.domain.dto.ExpenseDetailDTO;
 import mr.limpios.smart_divide_backend.domain.dto.ExpenseInputDTO;
+import mr.limpios.smart_divide_backend.domain.dto.ExpenseSummaryDTO;
 import mr.limpios.smart_divide_backend.domain.dto.UserBalanceDTO;
 import mr.limpios.smart_divide_backend.domain.events.ExpenseCreatedEvent;
 import mr.limpios.smart_divide_backend.domain.exceptions.ResourceNotFoundException;
@@ -212,12 +212,12 @@ public class ExpenseServiceTest {
         when(expenseRepository.findByGroupId(groupId)).thenReturn(List.of(expense));
 
         // Act
-        List<ExpenseDetailDTO> result = expenseService.getExpensesByGroup(groupId, userBalances, userId);
+        List<ExpenseSummaryDTO> result = expenseService.getExpensesByGroup(groupId, userBalances, userId);
 
         // Assert
         assertNotNull(result);
         assertEquals(1, result.size());
-        ExpenseDetailDTO detail = result.get(0);
+        ExpenseSummaryDTO detail = result.get(0);
 
         assertEquals(expense.id(), detail.id());
 

--- a/src/test/java/mr/limpios/smart_divide_backend/aplication/services/GroupServiceTest.java
+++ b/src/test/java/mr/limpios/smart_divide_backend/aplication/services/GroupServiceTest.java
@@ -25,7 +25,7 @@ import mr.limpios.smart_divide_backend.domain.models.Group;
 import mr.limpios.smart_divide_backend.domain.models.User;
 import mr.limpios.smart_divide_backend.domain.dto.AddMemberDTO;
 import mr.limpios.smart_divide_backend.domain.dto.CreateGroupDTO;
-import mr.limpios.smart_divide_backend.domain.dto.ExpenseDetailDTO;
+import mr.limpios.smart_divide_backend.domain.dto.ExpenseSummaryDTO;
 import mr.limpios.smart_divide_backend.domain.dto.GroupResumeDTO;
 import mr.limpios.smart_divide_backend.domain.dto.GroupTransactionHistoryDTO;
 import mr.limpios.smart_divide_backend.domain.dto.PaymentDetailDTO;
@@ -281,7 +281,7 @@ public class GroupServiceTest {
                 List<UserBalanceDTO> balances = Instancio.ofList(UserBalanceDTO.class)
                                 .size(3)
                                 .create();
-                List<ExpenseDetailDTO> expenses = Instancio.ofList(ExpenseDetailDTO.class)
+                List<ExpenseSummaryDTO> expenses = Instancio.ofList(ExpenseSummaryDTO.class)
                                 .size(5)
                                 .create();
                 List<PaymentDetailDTO> payments = Instancio.ofList(PaymentDetailDTO.class)

--- a/src/test/java/mr/limpios/smart_divide_backend/domain/validators/ExpenseValidatorTest.java
+++ b/src/test/java/mr/limpios/smart_divide_backend/domain/validators/ExpenseValidatorTest.java
@@ -14,8 +14,8 @@ import org.instancio.Instancio;
 import org.instancio.Select;
 import org.junit.jupiter.api.Test;
 
+import mr.limpios.smart_divide_backend.domain.dto.CreateExpenseParticipantDTO;
 import mr.limpios.smart_divide_backend.domain.dto.ExpenseInputDTO;
-import mr.limpios.smart_divide_backend.domain.dto.ExpenseParticipantDTO;
 import mr.limpios.smart_divide_backend.domain.exceptions.ResourceNotFoundException;
 import mr.limpios.smart_divide_backend.domain.models.User;
 
@@ -28,8 +28,8 @@ class ExpenseValidatorTest {
         Map<String, User> membersMap = Map.of("u1", u1, "u2", u2);
         String creatorId = "u1";
 
-        ExpenseParticipantDTO payer = new ExpenseParticipantDTO("u1", 100.0);
-        ExpenseParticipantDTO participant = new ExpenseParticipantDTO("u2", 100.0);
+        CreateExpenseParticipantDTO payer = new CreateExpenseParticipantDTO("u1", 100.0);
+        CreateExpenseParticipantDTO participant = new CreateExpenseParticipantDTO("u2", 100.0);
 
         ExpenseInputDTO dto = Instancio.of(ExpenseInputDTO.class)
             .set(Select.field(ExpenseInputDTO::payers), List.of(payer))
@@ -56,8 +56,8 @@ class ExpenseValidatorTest {
         Map<String, User> membersMap = Map.of("u1", Instancio.create(User.class));
         String creatorId = "u1";
 
-        ExpenseParticipantDTO validPayer = new ExpenseParticipantDTO("u1", 100.0);
-        ExpenseParticipantDTO invalidParticipant = new ExpenseParticipantDTO("unknown-user", 100.0);
+        CreateExpenseParticipantDTO validPayer = new CreateExpenseParticipantDTO("u1", 100.0);
+        CreateExpenseParticipantDTO invalidParticipant = new CreateExpenseParticipantDTO("unknown-user", 100.0);
 
         ExpenseInputDTO dto = Instancio.of(ExpenseInputDTO.class)
             .set(Select.field(ExpenseInputDTO::payers), List.of(validPayer))
@@ -75,8 +75,8 @@ class ExpenseValidatorTest {
         Map<String, User> membersMap = Map.of("u1", Instancio.create(User.class));
         String creatorId = "u1";
 
-        ExpenseParticipantDTO invalidPayer = new ExpenseParticipantDTO("unknown-user", 100.0);
-        ExpenseParticipantDTO validParticipant = new ExpenseParticipantDTO("u1", 100.0);
+        CreateExpenseParticipantDTO invalidPayer = new CreateExpenseParticipantDTO("unknown-user", 100.0);
+        CreateExpenseParticipantDTO validParticipant = new CreateExpenseParticipantDTO("u1", 100.0);
 
         ExpenseInputDTO dto = Instancio.of(ExpenseInputDTO.class)
             .set(Select.field(ExpenseInputDTO::payers), List.of(invalidPayer))

--- a/src/test/java/mr/limpios/smart_divide_backend/domain/validators/strategies/AbstractExpenseValidationStrategyTest.java
+++ b/src/test/java/mr/limpios/smart_divide_backend/domain/validators/strategies/AbstractExpenseValidationStrategyTest.java
@@ -12,8 +12,8 @@ import org.instancio.Instancio;
 import org.instancio.Select;
 import org.junit.jupiter.api.Test;
 
+import mr.limpios.smart_divide_backend.domain.dto.CreateExpenseParticipantDTO;
 import mr.limpios.smart_divide_backend.domain.dto.ExpenseInputDTO;
-import mr.limpios.smart_divide_backend.domain.dto.ExpenseParticipantDTO;
 import mr.limpios.smart_divide_backend.domain.exceptions.InvalidDataException;
 
 class AbstractExpenseValidationStrategyTest {
@@ -28,8 +28,8 @@ class AbstractExpenseValidationStrategyTest {
 
     @Test
     void validatePayers_success_amountsMatch() {
-        ExpenseParticipantDTO payer1 = new ExpenseParticipantDTO("u1", 60.00);
-        ExpenseParticipantDTO payer2 = new ExpenseParticipantDTO("u2", 40.00);
+        CreateExpenseParticipantDTO payer1 = new CreateExpenseParticipantDTO("u1", 60.00);
+        CreateExpenseParticipantDTO payer2 = new CreateExpenseParticipantDTO("u2", 40.00);
 
         ExpenseInputDTO dto = Instancio.of(ExpenseInputDTO.class)
             .set(Select.field(ExpenseInputDTO::amount), 100.00)
@@ -41,8 +41,8 @@ class AbstractExpenseValidationStrategyTest {
 
     @Test
     void validatePayers_fail_amountsMismatch() {
-        ExpenseParticipantDTO payer1 = new ExpenseParticipantDTO("u1", 60.00);
-        ExpenseParticipantDTO payer2 = new ExpenseParticipantDTO("u2", 30.00);
+        CreateExpenseParticipantDTO payer1 = new CreateExpenseParticipantDTO("u1", 60.00);
+        CreateExpenseParticipantDTO payer2 = new CreateExpenseParticipantDTO("u2", 30.00);
 
         ExpenseInputDTO dto = Instancio.of(ExpenseInputDTO.class)
             .set(Select.field(ExpenseInputDTO::amount), 100.00)
@@ -55,9 +55,9 @@ class AbstractExpenseValidationStrategyTest {
 
     @Test
     void getSumOfAmount_calculatesCorrectly() {
-        ExpenseParticipantDTO p1 = new ExpenseParticipantDTO("u1", 10.50);
-        ExpenseParticipantDTO p2 = new ExpenseParticipantDTO("u2", 20.25);
-        List<ExpenseParticipantDTO> list = List.of(p1, p2);
+        CreateExpenseParticipantDTO p1 = new CreateExpenseParticipantDTO("u1", 10.50);
+        CreateExpenseParticipantDTO p2 = new CreateExpenseParticipantDTO("u2", 20.25);
+        List<CreateExpenseParticipantDTO> list = List.of(p1, p2);
 
         BigDecimal result = strategy.getSumOfAmount(list);
 

--- a/src/test/java/mr/limpios/smart_divide_backend/domain/validators/strategies/EqualDivisionValidationStrategyTest.java
+++ b/src/test/java/mr/limpios/smart_divide_backend/domain/validators/strategies/EqualDivisionValidationStrategyTest.java
@@ -11,8 +11,8 @@ import java.util.List;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
+import mr.limpios.smart_divide_backend.domain.dto.CreateExpenseParticipantDTO;
 import mr.limpios.smart_divide_backend.domain.dto.ExpenseInputDTO;
-import mr.limpios.smart_divide_backend.domain.dto.ExpenseParticipantDTO;
 import mr.limpios.smart_divide_backend.domain.exceptions.InvalidDataException;
 
 class EqualDivisionValidationStrategyTest {
@@ -21,10 +21,10 @@ class EqualDivisionValidationStrategyTest {
 
     @Test
     void validate_success_exactDivision() {
-        ExpenseParticipantDTO p1 = new ExpenseParticipantDTO("u1", 50.00);
-        ExpenseParticipantDTO p2 = new ExpenseParticipantDTO("u2", 50.00);
+        CreateExpenseParticipantDTO p1 = new CreateExpenseParticipantDTO("u1", 50.00);
+        CreateExpenseParticipantDTO p2 = new CreateExpenseParticipantDTO("u2", 50.00);
         
-        ExpenseParticipantDTO payer = new ExpenseParticipantDTO("u1", 100.00);
+        CreateExpenseParticipantDTO payer = new CreateExpenseParticipantDTO("u1", 100.00);
 
         ExpenseInputDTO dto = Instancio.of(ExpenseInputDTO.class)
             .set(org.instancio.Select.field(ExpenseInputDTO::amount), 100.00)
@@ -37,11 +37,11 @@ class EqualDivisionValidationStrategyTest {
 
     @Test
     void validate_success_withRoundingCents() {
-        ExpenseParticipantDTO p1 = new ExpenseParticipantDTO("u1", 33.33);
-        ExpenseParticipantDTO p2 = new ExpenseParticipantDTO("u2", 33.33);
-        ExpenseParticipantDTO p3 = new ExpenseParticipantDTO("u3", 33.34);
+        CreateExpenseParticipantDTO p1 = new CreateExpenseParticipantDTO("u1", 33.33);
+        CreateExpenseParticipantDTO p2 = new CreateExpenseParticipantDTO("u2", 33.33);
+        CreateExpenseParticipantDTO p3 = new CreateExpenseParticipantDTO("u3", 33.34);
         
-        ExpenseParticipantDTO payer = new ExpenseParticipantDTO("u1", 100.00);
+        CreateExpenseParticipantDTO payer = new CreateExpenseParticipantDTO("u1", 100.00);
 
         ExpenseInputDTO dto = Instancio.of(ExpenseInputDTO.class)
             .set(org.instancio.Select.field(ExpenseInputDTO::amount), 100.00)
@@ -54,10 +54,10 @@ class EqualDivisionValidationStrategyTest {
 
     @Test
     void validate_fail_totalAmountMismatch() {
-        ExpenseParticipantDTO p1 = new ExpenseParticipantDTO("u1", 40.00);
-        ExpenseParticipantDTO p2 = new ExpenseParticipantDTO("u2", 40.00);
+        CreateExpenseParticipantDTO p1 = new CreateExpenseParticipantDTO("u1", 40.00);
+        CreateExpenseParticipantDTO p2 = new CreateExpenseParticipantDTO("u2", 40.00);
         
-        ExpenseParticipantDTO payer = new ExpenseParticipantDTO("u1", 100.00);
+        CreateExpenseParticipantDTO payer = new CreateExpenseParticipantDTO("u1", 100.00);
 
         ExpenseInputDTO dto = Instancio.of(ExpenseInputDTO.class)
             .set(org.instancio.Select.field(ExpenseInputDTO::amount), 100.00)
@@ -71,10 +71,10 @@ class EqualDivisionValidationStrategyTest {
 
     @Test
     void validate_fail_unequalDivision() {
-        ExpenseParticipantDTO p1 = new ExpenseParticipantDTO("u1", 20.00);
-        ExpenseParticipantDTO p2 = new ExpenseParticipantDTO("u2", 80.00);
+        CreateExpenseParticipantDTO p1 = new CreateExpenseParticipantDTO("u1", 20.00);
+        CreateExpenseParticipantDTO p2 = new CreateExpenseParticipantDTO("u2", 80.00);
         
-        ExpenseParticipantDTO payer = new ExpenseParticipantDTO("u1", 100.00);
+        CreateExpenseParticipantDTO payer = new CreateExpenseParticipantDTO("u1", 100.00);
 
         ExpenseInputDTO dto = Instancio.of(ExpenseInputDTO.class)
             .set(org.instancio.Select.field(ExpenseInputDTO::amount), 100.00)

--- a/src/test/java/mr/limpios/smart_divide_backend/domain/validators/strategies/SumMatchValidationStrategyTest.java
+++ b/src/test/java/mr/limpios/smart_divide_backend/domain/validators/strategies/SumMatchValidationStrategyTest.java
@@ -12,8 +12,8 @@ import org.instancio.Instancio;
 import org.instancio.Select;
 import org.junit.jupiter.api.Test;
 
+import mr.limpios.smart_divide_backend.domain.dto.CreateExpenseParticipantDTO;
 import mr.limpios.smart_divide_backend.domain.dto.ExpenseInputDTO;
-import mr.limpios.smart_divide_backend.domain.dto.ExpenseParticipantDTO;
 import mr.limpios.smart_divide_backend.domain.exceptions.InvalidDataException;
 
 class SumMatchValidationStrategyTest {
@@ -22,10 +22,10 @@ class SumMatchValidationStrategyTest {
 
     @Test
     void validate_success_sumsMatch() {
-        ExpenseParticipantDTO part1 = new ExpenseParticipantDTO("u1", 40.00);
-        ExpenseParticipantDTO part2 = new ExpenseParticipantDTO("u2", 60.00);
+        CreateExpenseParticipantDTO part1 = new CreateExpenseParticipantDTO("u1", 40.00);
+        CreateExpenseParticipantDTO part2 = new CreateExpenseParticipantDTO("u2", 60.00);
         
-        ExpenseParticipantDTO payer1 = new ExpenseParticipantDTO("u1", 100.00);
+        CreateExpenseParticipantDTO payer1 = new CreateExpenseParticipantDTO("u1", 100.00);
 
         ExpenseInputDTO dto = Instancio.of(ExpenseInputDTO.class)
             .set(Select.field(ExpenseInputDTO::amount), 100.00)
@@ -38,10 +38,10 @@ class SumMatchValidationStrategyTest {
 
     @Test
     void validate_fail_participantsSumMismatch() {
-        ExpenseParticipantDTO part1 = new ExpenseParticipantDTO("u1", 40.00);
-        ExpenseParticipantDTO part2 = new ExpenseParticipantDTO("u2", 40.00); 
+        CreateExpenseParticipantDTO part1 = new CreateExpenseParticipantDTO("u1", 40.00);
+        CreateExpenseParticipantDTO part2 = new CreateExpenseParticipantDTO("u2", 40.00); 
         
-        ExpenseParticipantDTO payer1 = new ExpenseParticipantDTO("u1", 100.00);
+        CreateExpenseParticipantDTO payer1 = new CreateExpenseParticipantDTO("u1", 100.00);
 
         ExpenseInputDTO dto = Instancio.of(ExpenseInputDTO.class)
             .set(Select.field(ExpenseInputDTO::amount), 100.00)
@@ -55,10 +55,10 @@ class SumMatchValidationStrategyTest {
 
     @Test
     void validate_fail_payersSumMismatch() {
-        ExpenseParticipantDTO part1 = new ExpenseParticipantDTO("u1", 50.00);
-        ExpenseParticipantDTO part2 = new ExpenseParticipantDTO("u2", 50.00);
+        CreateExpenseParticipantDTO part1 = new CreateExpenseParticipantDTO("u1", 50.00);
+        CreateExpenseParticipantDTO part2 = new CreateExpenseParticipantDTO("u2", 50.00);
         
-        ExpenseParticipantDTO payer1 = new ExpenseParticipantDTO("u1", 90.00); 
+        CreateExpenseParticipantDTO payer1 = new CreateExpenseParticipantDTO("u1", 90.00); 
 
         ExpenseInputDTO dto = Instancio.of(ExpenseInputDTO.class)
             .set(Select.field(ExpenseInputDTO::amount), 100.00)


### PR DESCRIPTION
Implements an endpoint to retrieve detailed information about a specific expense. This includes details about payers, participants, and balances, offering a comprehensive view of the expense. Also renames `ExpenseParticipantDTO` to `CreateExpenseParticipantDTO` for more accuracy.